### PR TITLE
chore(release): 2.1.0-beta.1 - 20200525 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [2.1.0-beta.1](https://github.com/cenk1cenk2/listr2/compare/v2.0.4...v2.1.0-beta.1) (2020-05-25)
+
+
+### Bug Fixes
+
+* **figures:** made microsoft icons to use the fancy ones, even though it may fail in some cases ([f0e5817](https://github.com/cenk1cenk2/listr2/commit/f0e581706e59d9b96da9bd050a1ad3638b59c2aa)), closes [#31](https://github.com/cenk1cenk2/listr2/issues/31)
+
+
+### Features
+
+* **renderer:** added hook and stdout support ([bd73c68](https://github.com/cenk1cenk2/listr2/commit/bd73c68b9eb21cd100a266ce05ba36af0c727a4f)), closes [#31](https://github.com/cenk1cenk2/listr2/issues/31)
+
 ## [2.0.4](https://github.com/cenk1cenk2/listr2/compare/v2.0.3...v2.0.4) (2020-05-20)
 
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This is the expanded and re-written in Typescript version of the beautiful plugi
     - [Utilizing the Task Itself](#utilizing-the-task-itself)
     - [Utilizing the Bottom Bar](#utilizing-the-bottom-bar)
     - [Utilizing an Observable or Stream](#utilizing-an-observable-or-stream)
+    - [Passing the Output Through as a Stream](#passing-the-output-through-as-a-stream)
   - [Throw Errors](#throw-errors)
 - [Task Manager](#task-manager)
   - [Basic Use-Case Scenerio](#basic-use-case-scenerio)
@@ -44,9 +45,9 @@ This is the expanded and re-written in Typescript version of the beautiful plugi
 - [Testing](#testing)
 - [Default Renderers](#default-renderers)
 - [Custom Renderers](#custom-renderers)
+- [Render Hooks](#render-hooks)
 - [Log To A File](#log-to-a-file)
-- [Migration from Version <v1.3.12](#migration-from-version-v1312)
-  - [Details](#details)
+- [Migration from Version v1](#migration-from-version-v1)
 - [Types](#types)
 
 <!-- tocstop -->


### PR DESCRIPTION
# [2.1.0-beta.1](https://github.com/cenk1cenk2/listr2/compare/v2.0.4...v2.1.0-beta.1) (2020-05-25)

### Bug Fixes

* **figures:** made microsoft icons to use the fancy ones, even though it may fail in some cases ([f0e5817](https://github.com/cenk1cenk2/listr2/commit/f0e581706e59d9b96da9bd050a1ad3638b59c2aa)), closes [#31](https://github.com/cenk1cenk2/listr2/issues/31)

### Features

* **renderer:** added hook and stdout support ([bd73c68](https://github.com/cenk1cenk2/listr2/commit/bd73c68b9eb21cd100a266ce05ba36af0c727a4f)), closes [#31](https://github.com/cenk1cenk2/listr2/issues/31)