### PR TITLE
fix(renderer): add skip to verbose output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.1.7](https://github.com/cenk1cenk2/listr2/compare/v2.1.6...v2.1.7) (2020-06-14)
+
+
+### Bug Fixes
+
+* **renderer:** verbose renderer ([794f966](https://github.com/cenk1cenk2/listr2/commit/794f9667f8d2b1715f76a841dcb73f47bf8d6aca))
+
 ## [2.1.6](https://github.com/cenk1cenk2/listr2/compare/v2.1.5...v2.1.6) (2020-06-14)
 
 

--- a/src/renderer/verbose.renderer.ts
+++ b/src/renderer/verbose.renderer.ts
@@ -50,6 +50,8 @@ export class VerboseRenderer implements ListrRenderer {
                   this.logger.start(taskTitle)
                 } else if (task.isCompleted()) {
                   this.logger.success(taskTitle)
+                } else if (task.isSkipped()) {
+                  this.logger.skip(task.output)
                 }
               }
             } else if (event.type === 'DATA') {
@@ -61,7 +63,7 @@ export class VerboseRenderer implements ListrRenderer {
               } else {
                 this.logger.data(String(event.data))
               }
-            } else if (event.type === 'TITLE' ) {
+            } else if (event.type === 'TITLE') {
               if (this.options?.logTitleChange !== false) {
                 this.logger.title(String(event.data))
               }

--- a/tests/task-skip.e2e-spec.ts
+++ b/tests/task-skip.e2e-spec.ts
@@ -29,6 +29,22 @@ describe('skip a task', () => {
     expect(warn).toBeCalledWith('[SKIPPED] skipped')
   })
 
+  it('should skip the task from skip method', async () => {
+    await new Listr([
+      {
+        skip() {
+          return 'skipped'
+        },
+        task: async (ctx, task): Promise<void> => {
+          
+        }
+      }
+    ], { renderer: 'verbose' }).run()
+
+    expect(log).toBeCalledWith('[STARTED] Task without title.')
+    expect(warn).toBeCalledWith('[SKIPPED] skipped')
+  })
+
   it('skip to enable by context will work properly in serial', async () => {
     await new Listr([
       {


### PR DESCRIPTION
Previously the verbose output would only include the skip output if one called the task.skip. However in our cli we use the skip method and it returns a string. Since this is covered in the default renderer, it seems this use case was missing in the verbose.