### PR TITLE
Logger updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.1.8](https://github.com/cenk1cenk2/listr2/compare/v2.1.7...v2.1.8) (2020-06-17)
+
+
+### Bug Fixes
+
+* **renderer:** add skip to verbose output ([f577df0](https://github.com/cenk1cenk2/listr2/commit/f577df08720a6602a46b9eec457a9d55321d89d7))
+
 ## [2.1.7](https://github.com/cenk1cenk2/listr2/compare/v2.1.6...v2.1.7) (2020-06-14)
 
 

--- a/README.md
+++ b/README.md
@@ -1112,10 +1112,12 @@ Logging to a file can be done utilizing a module like [winston](https://www.npmj
 While calling a new Listr you can call it with `{ renderer: 'verbose', rendererOptions: { logger: MyLoggerClass } }`.
 
 ```typescript
-import { logLevels, Logger } from 'listr2'
+import { logLevels, Logger, LoggerOptions } from 'listr2'
 
-export class MyLoggerClass implements Logger {
-  constructor(private options?: LoggerOptions) {}
+export class MyLoggerClass extends Logger {
+  constructor(private options?: LoggerOptions) {
+    // This is not needed if you don't use these options in your custom logger
+  }
 
   /* CUSTOM LOGIC */
   /* CUSTOM LOGIC */

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -18,7 +18,7 @@ export class Logger {
 
   public skip (message: string): void {
     message = this.parseMessage(logLevels.skip, message)
-    console.warn(message)
+    console.info(message)
   }
 
   public success (message: string): void {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -41,7 +41,7 @@ export class Logger {
     console.info(message)
   }
 
-  private parseMessage (level: logLevels, message: string): string {
+  protected parseMessage (level: logLevels, message: string): string {
     // parse multi line messages
     let multiLineMessage: string[]
 
@@ -64,7 +64,7 @@ export class Logger {
     return message
   }
 
-  private logColoring ({ level, message }: { level: logLevels, message: string }): string {
+  protected logColoring ({ level, message }: { level: logLevels, message: string }): string {
     let icon: string
 
     // do the coloring


### PR DESCRIPTION
So I noticed in our CI after moving to listr2 that skip causes our builds to fail. This is because skip calls `console.warn`, which is an alias for `console.error` 😬. 

I considered writing a custom logger but that proved to be a bit harder since we rely on default behavior of using the default renderer when TTY is enabled and verbose when not. Which causes issues with TS.