### PR TITLE
feat: display elegant spinner on Windows Terminal

### DIFF
--- a/src/renderer/default.renderer.ts
+++ b/src/renderer/default.renderer.ts
@@ -29,7 +29,7 @@ export class DefaultRenderer implements ListrRenderer {
   private id?: NodeJS.Timeout
   private bottomBar: { [uuid: string]: { data?: string[], items?: number } } = {}
   private promptBar: string
-  private spinner: string[] = process.platform === 'win32' ? [ '-', '\\', '|', '/' ] : [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ]
+  private spinner: string[] = process.platform === 'win32' && !process.env.WT_SESSION ? [ '-', '\\', '|', '/' ] : [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ]
   private spinnerPosition = 0
 
   constructor (


### PR DESCRIPTION
On `conhost.exe`, these characters were not supported. But on Windows Terminal, they are. The Windows Terminal adds the [`WT_SESSION`](https://github.com/microsoft/terminal/issues/840) environment variable, which allows to identify when it's used. Thanks to that, we can now display fancy figures on Windows. 

This change updates the previous behavior by adding an additional check against the `WT_SESSION` environment variable, in order to allow these characters on the Windows Terminal.

![](https://camo.githubusercontent.com/9a13db8710133f2c683b9776f866db90e2140ba5/68747470733a2f2f692e696d6775722e636f6d2f32344a666632572e706e67)

Sources:
- https://github.com/microsoft/terminal/issues/840

Related:
- https://github.com/sindresorhus/elegant-spinner/pull/5
- https://github.com/sindresorhus/log-symbols/pull/24
- https://github.com/sindresorhus/figures/pull/34
