### PR TITLE
Add ability for showing duration of tasks

### DIFF
--- a/src/interfaces/listr.interface.ts
+++ b/src/interfaces/listr.interface.ts
@@ -31,11 +31,14 @@ export declare class ListrClass<
 export interface ListrTaskObject<Ctx, Renderer extends ListrRendererFactory> extends Observable<ListrEvent> {
   id: string
   title?: string
+  originalTitle?: string
   output?: string
   task: (ctx: Ctx, task: ListrTaskWrapper<Ctx, Renderer>) => void | ListrTaskResult<Ctx>
   skip: boolean | string | ((ctx: Ctx) => boolean | string | Promise<boolean> | Promise<string>)
   subtasks: ListrTaskObject<Ctx, any>[]
   state: string
+  startTime?: number
+  duration?: string
   check: (ctx: Ctx) => void
   run: (ctx: Ctx, wrapper: ListrTaskWrapper<Ctx, Renderer>) => Promise<void>
   options: ListrOptions


### PR DESCRIPTION
This adds the behavior of adding the ability to time tasks as defined [here](https://github.com/SamVerschueren/listr-update-renderer/pull/24) and adds it to the default renderer

It adds the flag `showTimer` to the renderer options and then displays a timer next to the title in form `title [00:00]`

I won't have much time to refactor this in the upcoming days, so I will leave this up to you to do with what you want