### PR TITLE
Add prompt cancel

### DIFF
--- a/examples/get-user-input.example.ts
+++ b/examples/get-user-input.example.ts
@@ -206,10 +206,18 @@ async function main(): Promise<void> {
           })
 
           delay(1000).then(() => task.cancelPrompt())
-          ctx.input = await task.prompt({
-            type: 'Input',
-            message: 'This one will disappear too.'
-          })
+          ctx.input = await task.prompt([
+            {
+              name: 'hello',
+              type: 'Input',
+              message: 'This one will disappear.'
+            },
+            {
+              name: 'hello2',
+              type: 'Input',
+              message: "But this one won't."
+            }
+          ])
 
           delay(1000).then(() => task.cancelPrompt(true))
           ctx.input = await task.prompt({

--- a/examples/get-user-input.example.ts
+++ b/examples/get-user-input.example.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import delay from 'delay'
-
-import { Listr } from '../src/index'
 import { Logger } from '@utils/logger'
+import delay from 'delay'
+import { Listr } from '../src/index'
 
 interface Ctx {
   input: boolean | Record<string, boolean>
@@ -10,7 +9,7 @@ interface Ctx {
 
 const logger = new Logger({ useIcons: false })
 
-async function main (): Promise<void> {
+async function main(): Promise<void> {
   let task: Listr<Ctx>
 
   logger.start('Example for getting user input.')
@@ -20,12 +19,12 @@ async function main (): Promise<void> {
       {
         title: 'This task will get your input.',
         task: async (ctx, task): Promise<Record<string, boolean>> =>
-          ctx.input = await task.prompt<{ test: boolean, other: boolean }>([
+          (ctx.input = await task.prompt<{ test: boolean; other: boolean }>([
             {
               type: 'Select',
               name: 'first',
               message: 'Please select something',
-              choices: [ 'A', 'B', 'C' ],
+              choices: ['A', 'B', 'C'],
               validate: (response): boolean | string => {
                 //  i do declare you valid!
                 if (response === 'A') {
@@ -38,7 +37,7 @@ async function main (): Promise<void> {
               name: 'second',
               message: 'Please type something in:'
             }
-          ])
+          ]))
       },
       {
         title: 'Now I will show the input value.',
@@ -93,7 +92,7 @@ async function main (): Promise<void> {
           ctx.input = await task.prompt<boolean>({
             type: 'Select',
             message: 'Do you love me?',
-            choices: [ 'test', 'test', 'test', 'test' ]
+            choices: ['test', 'test', 'test', 'test']
           })
         }
       }
@@ -124,7 +123,7 @@ async function main (): Promise<void> {
               { name: '4', message: 'Agree' },
               { name: '5', message: 'Strongly Agree' }
             ],
-            margin: [ 0, 0, 2, 1 ],
+            margin: [0, 0, 2, 1],
             choices: [
               {
                 name: 'interface',
@@ -178,6 +177,54 @@ async function main (): Promise<void> {
       {
         title: 'Another task.',
         task: async (): Promise<void> => {
+          await delay(1000)
+        }
+      }
+    ],
+    {
+      concurrent: false
+    }
+  )
+
+  try {
+    const context = await task.run()
+    logger.success(`Context: ${JSON.stringify(context)}`)
+  } catch (e) {
+    logger.fail(e)
+  }
+
+  logger.start('Canceling a prompt.')
+  task = new Listr<Ctx>(
+    [
+      {
+        title: 'This task will execute and cancel the prompts.',
+        task: async (ctx, task): Promise<void> => {
+          delay(1000).then(() => task.cancelPrompt())
+          ctx.input = await task.prompt({
+            type: 'Input',
+            message: 'Give me input before it disappears.'
+          })
+
+          delay(1000).then(() => task.cancelPrompt())
+          ctx.input = await task.prompt({
+            type: 'Input',
+            message: 'This one will disappear too.'
+          })
+
+          delay(1000).then(() => task.cancelPrompt(true))
+          ctx.input = await task.prompt({
+            type: 'Input',
+            message: 'This input will throw an error :/.'
+          })
+        }
+      },
+      {
+        title: 'Another task.',
+        task: async (ctx, task): Promise<void> => {
+          ctx.input = await task.prompt({
+            type: 'Input',
+            message: 'Prompt afterwards.'
+          })
           await delay(1000)
         }
       }

--- a/src/interfaces/listr.interface.ts
+++ b/src/interfaces/listr.interface.ts
@@ -1,7 +1,3 @@
-import Enquirer from 'enquirer'
-import { Observable, Subject } from 'rxjs'
-import { Readable } from 'stream'
-
 import { stateConstants } from '@interfaces/state.constants'
 import { Task } from '@lib/task'
 import { DefaultRenderer } from '@renderer/default.renderer'
@@ -9,6 +5,9 @@ import { SilentRenderer } from '@renderer/silent.renderer'
 import { VerboseRenderer } from '@renderer/verbose.renderer'
 import { Listr } from '@root/index'
 import { PromptOptions } from '@utils/prompt.interface'
+import Enquirer from 'enquirer'
+import { Observable, Subject } from 'rxjs'
+import { Readable } from 'stream'
 
 export type ListrContext = any
 
@@ -23,9 +22,9 @@ export declare class ListrClass<
   FallbackRenderer extends ListrRendererValue = ListrFallbackRendererValue
 > {
   tasks: Task<Ctx, ListrGetRendererClassFromValue<Renderer>>[]
-  constructor (task?: readonly ListrTask<Ctx, ListrGetRendererClassFromValue<Renderer>>[], options?: ListrBaseClassOptions<Ctx, Renderer, FallbackRenderer>)
-  public run (ctx?: Ctx): Promise<Ctx>
-  public add (tasks: ListrTask<Ctx, ListrGetRendererClassFromValue<Renderer>> | readonly ListrTask<Ctx, ListrGetRendererClassFromValue<Renderer>>[]): void
+  constructor(task?: readonly ListrTask<Ctx, ListrGetRendererClassFromValue<Renderer>>[], options?: ListrBaseClassOptions<Ctx, Renderer, FallbackRenderer>)
+  public run(ctx?: Ctx): Promise<Ctx>
+  public add(tasks: ListrTask<Ctx, ListrGetRendererClassFromValue<Renderer>> | readonly ListrTask<Ctx, ListrGetRendererClassFromValue<Renderer>>[]): void
 }
 
 export interface ListrTaskObject<Ctx, Renderer extends ListrRendererFactory> extends Observable<ListrEvent> {
@@ -76,6 +75,7 @@ export interface ListrTaskWrapper<Ctx, Renderer extends ListrRendererFactory> {
   skip(message?: string): void
   run(ctx?: Ctx, task?: ListrTaskWrapper<Ctx, Renderer>): Promise<void>
   prompt<T = any>(options: PromptOptions | PromptOptions<true>[]): Promise<T>
+  cancelPrompt(throwError?: boolean): void
   stdout(): NodeJS.WritableStream
 }
 
@@ -88,7 +88,7 @@ export type ListrBaseClassOptions<
 > = ListrOptions<Ctx> & ListrDefaultRendererOptions<Renderer> & ListrDefaultNonTTYRendererOptions<FallbackRenderer>
 
 export type ListrSubClassOptions<Ctx = ListrContext, Renderer extends ListrRendererValue = ListrDefaultRendererValue> = ListrOptions<Ctx> &
-Omit<ListrDefaultRendererOptions<Renderer>, 'renderer'>
+  Omit<ListrDefaultRendererOptions<Renderer>, 'renderer'>
 
 export interface ListrOptions<Ctx = ListrContext> {
   concurrent?: boolean | number
@@ -109,42 +109,42 @@ export type CreateClass<T> = new (...args: any[]) => T
 export type ListrGetRendererClassFromValue<T extends ListrRendererValue> = T extends 'default'
   ? typeof DefaultRenderer
   : T extends 'verbose'
-    ? typeof VerboseRenderer
-    : T extends 'silent'
-      ? typeof SilentRenderer
-      : T extends ListrRendererFactory
-        ? T
-        : never
+  ? typeof VerboseRenderer
+  : T extends 'silent'
+  ? typeof SilentRenderer
+  : T extends ListrRendererFactory
+  ? T
+  : never
 
 export type ListrGetRendererValueFromClass<T extends ListrRendererFactory> = T extends DefaultRenderer
   ? 'default'
   : T extends VerboseRenderer
-    ? 'verbose'
-    : T extends SilentRenderer
-      ? 'silent'
-      : T extends ListrRendererFactory
-        ? T
-        : never
+  ? 'verbose'
+  : T extends SilentRenderer
+  ? 'silent'
+  : T extends ListrRendererFactory
+  ? T
+  : never
 
 export type ListrGetRendererOptions<T extends ListrRendererValue> = T extends 'default'
   ? typeof DefaultRenderer['rendererOptions']
   : T extends 'verbose'
-    ? typeof VerboseRenderer['rendererOptions']
-    : T extends 'silent'
-      ? typeof SilentRenderer['rendererOptions']
-      : T extends ListrRendererFactory
-        ? T['rendererOptions']
-        : never
+  ? typeof VerboseRenderer['rendererOptions']
+  : T extends 'silent'
+  ? typeof SilentRenderer['rendererOptions']
+  : T extends ListrRendererFactory
+  ? T['rendererOptions']
+  : never
 
 export type ListrGetRendererTaskOptions<T extends ListrRendererValue> = T extends 'default'
   ? typeof DefaultRenderer['rendererTaskOptions']
   : T extends 'verbose'
-    ? typeof VerboseRenderer['rendererTaskOptions']
-    : T extends 'silent'
-      ? typeof SilentRenderer['rendererTaskOptions']
-      : T extends ListrRendererFactory
-        ? T['rendererTaskOptions']
-        : never
+  ? typeof VerboseRenderer['rendererTaskOptions']
+  : T extends 'silent'
+  ? typeof SilentRenderer['rendererTaskOptions']
+  : T extends ListrRendererFactory
+  ? T['rendererTaskOptions']
+  : never
 
 export interface ListrDefaultRendererOptions<T extends ListrRendererValue> {
   renderer?: T
@@ -157,15 +157,15 @@ export interface ListrDefaultNonTTYRendererOptions<T extends ListrRendererValue>
 }
 
 export type ListrRendererOptions<Renderer extends ListrRendererValue, FallbackRenderer extends ListrRendererValue> = ListrDefaultRendererOptions<Renderer> &
-ListrDefaultNonTTYRendererOptions<FallbackRenderer>
+  ListrDefaultNonTTYRendererOptions<FallbackRenderer>
 
 export declare class ListrRenderer {
   public static rendererOptions: Record<string, any>
   public static rendererTaskOptions: Record<string, any>
   public static nonTTY: boolean
-  constructor (tasks: readonly ListrTaskObject<any, ListrRendererFactory>[], options: typeof ListrRenderer.rendererOptions)
-  public render (): void
-  public end (err?: Error): void
+  constructor(tasks: readonly ListrTaskObject<any, ListrRendererFactory>[], options: typeof ListrRenderer.rendererOptions)
+  public render(): void
+  public end(err?: Error): void
 }
 
 export declare class ListrBaseRenderer implements ListrRenderer /* istanbul ignore next */ {
@@ -175,9 +175,9 @@ export declare class ListrBaseRenderer implements ListrRenderer /* istanbul igno
   public tasks: ListrTaskObject<any, typeof ListrBaseRenderer>[]
   public options: typeof ListrBaseRenderer.rendererOptions
   /* istanbul ignore next */
-  constructor (tasks: ListrTaskObject<any, typeof ListrBaseRenderer>[], options: typeof ListrBaseRenderer.rendererOptions)
-  public render (): void
-  public end (err?: Error): void
+  constructor(tasks: ListrTaskObject<any, typeof ListrBaseRenderer>[], options: typeof ListrBaseRenderer.rendererOptions)
+  public render(): void
+  public end(err?: Error): void
 }
 
 export interface ListrRendererFactory {
@@ -191,23 +191,23 @@ export type ListrRendererValue = 'silent' | 'default' | 'verbose' | ListrRendere
 
 export type ListrEvent =
   | {
-    type: Exclude<ListrEventTypes, 'MESSAGE'>
-    data?: string | boolean
-  }
+      type: Exclude<ListrEventTypes, 'MESSAGE'>
+      data?: string | boolean
+    }
   | {
-    type: 'MESSAGE'
-    data: ListrTaskObject<any, any>['message']
-  }
+      type: 'MESSAGE'
+      data: ListrTaskObject<any, any>['message']
+    }
 
 export class ListrError extends Error {
-  constructor (public message: string, public errors?: Error[], public context?: any) {
+  constructor(public message: string, public errors?: Error[], public context?: any) {
     super(message)
     this.name = 'ListrError'
   }
 }
 
 export class PromptError extends Error {
-  constructor (message) {
+  constructor(message) {
     super(message)
     this.name = 'PromptError'
   }

--- a/src/lib/task-wrapper.ts
+++ b/src/lib/task-wrapper.ts
@@ -13,7 +13,7 @@ import { stateConstants } from '@interfaces/state.constants'
 import { Task } from '@lib/task'
 import { Listr } from '@root/index'
 import { createPrompt, destroyPrompt } from '@utils/prompt'
-import { PromptInstance, PromptOptions } from '@utils/prompt.interface'
+import { PromptOptions } from '@utils/prompt.interface'
 import through from 'through'
 
 export class TaskWrapper<Ctx, Renderer extends ListrRendererFactory> implements ListrTaskWrapper<Ctx, Renderer> {
@@ -26,16 +26,6 @@ export class TaskWrapper<Ctx, Renderer extends ListrRendererFactory> implements 
   /* istanbul ignore next */
   get title(): string {
     return this.task.title
-  }
-
-  _promptInstance: PromptInstance
-  set promptInstance(data: PromptInstance) {
-    this._promptInstance = data
-  }
-
-  /* istanbul ignore next */
-  get promptInstance(): PromptInstance {
-    return this._promptInstance
   }
 
   set output(data: string) {

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -1,7 +1,3 @@
-import Enquirer from 'enquirer'
-import { Observable, Subject } from 'rxjs'
-import { Readable } from 'stream'
-
 import {
   ListrContext,
   ListrError,
@@ -18,8 +14,11 @@ import {
 } from '@interfaces/listr.interface'
 import { stateConstants } from '@interfaces/state.constants'
 import { Listr } from '@root/index'
+import { PromptInstance } from '@utils/prompt.interface'
 import { getRenderer } from '@utils/renderer'
 import { generateUUID } from '@utils/uuid'
+import { Observable, Subject } from 'rxjs'
+import { Readable } from 'stream'
 
 export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<ListrEvent> implements ListrTaskObject<ListrContext, Renderer> {
   public id: ListrTaskObject<Ctx, Renderer>['id']
@@ -30,14 +29,14 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
   public output: ListrTaskObject<Ctx, Renderer>['output']
   public title: ListrTaskObject<Ctx, Renderer>['title']
   public message: ListrTaskObject<Ctx, Renderer>['message'] = {}
-  public prompt: boolean | PromptError
+  public prompt: undefined | PromptInstance | PromptError
   public exitOnError: boolean
   public rendererTaskOptions: ListrGetRendererTaskOptions<Renderer>
   public renderHook$: Subject<void>
   private enabled: boolean
   private enabledFn: ListrTask<Ctx, Renderer>['enabled']
 
-  constructor (public listr: Listr<Ctx, any, any>, public tasks: ListrTask<Ctx, any>, public options: ListrOptions, public rendererOptions: ListrGetRendererOptions<Renderer>) {
+  constructor(public listr: Listr<Ctx, any, any>, public tasks: ListrTask<Ctx, any>, public options: ListrOptions, public rendererOptions: ListrGetRendererOptions<Renderer>) {
     super()
 
     // this kind of randomness is enough for task ids
@@ -58,7 +57,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
     })
   }
 
-  set state$ (state: StateConstants) {
+  set state$(state: StateConstants) {
     this.state = state
 
     this.next({
@@ -76,7 +75,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
     }
   }
 
-  set output$ (data: string) {
+  set output$(data: string) {
     this.output = data
 
     this.next({
@@ -85,7 +84,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
     })
   }
 
-  set message$ (data: ListrTaskObject<Ctx, Renderer>['message']) {
+  set message$(data: ListrTaskObject<Ctx, Renderer>['message']) {
     this.message = { ...this.message, ...data }
 
     this.next({
@@ -94,7 +93,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
     })
   }
 
-  set title$ (title: string) {
+  set title$(title: string) {
     this.title = title
 
     this.next({
@@ -103,7 +102,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
     })
   }
 
-  async check (ctx: Ctx): Promise<void> {
+  async check(ctx: Ctx): Promise<void> {
     // Check if a task is enabled or disabled
     if (this.state === undefined) {
       if (typeof this.enabledFn === 'function') {
@@ -119,35 +118,35 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
     }
   }
 
-  hasSubtasks (): boolean {
+  hasSubtasks(): boolean {
     return this.subtasks?.length > 0
   }
 
-  isPending (): boolean {
+  isPending(): boolean {
     return this.state === stateConstants.PENDING
   }
 
-  isSkipped (): boolean {
+  isSkipped(): boolean {
     return this.state === stateConstants.SKIPPED
   }
 
-  isCompleted (): boolean {
+  isCompleted(): boolean {
     return this.state === stateConstants.COMPLETED
   }
 
-  hasFailed (): boolean {
+  hasFailed(): boolean {
     return this.state === stateConstants.FAILED
   }
 
-  isEnabled (): boolean {
+  isEnabled(): boolean {
     return this.enabled
   }
 
-  hasTitle (): boolean {
+  hasTitle(): boolean {
     return typeof this?.title === 'string'
   }
 
-  isPrompt (): boolean {
+  isPrompt(): boolean {
     if (this.prompt) {
       return true
     } else {
@@ -155,7 +154,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
     }
   }
 
-  async run (context: Ctx, wrapper: ListrTaskWrapper<Ctx, Renderer>): Promise<void> {
+  async run(context: Ctx, wrapper: ListrTaskWrapper<Ctx, Renderer>): Promise<void> {
     const handleResult = (result): Promise<any> => {
       if (result instanceof Listr) {
         // Detect the subtask

--- a/src/utils/prompt.interface.ts
+++ b/src/utils/prompt.interface.ts
@@ -1,20 +1,19 @@
+import { PromptError } from '@interfaces/listr.interface'
 import Enquirer from 'enquirer'
 import { WriteStream } from 'fs'
 import { Writable } from 'stream'
 
-import { PromptError } from '@interfaces/listr.interface'
-
 export type PromptOptions<T extends boolean = false> =
   | Unionize<
-  {
-    [K in PromptTypes]-?: T extends true ? { type: K } & PromptOptionsType<K> & { name: string | (() => string) } : { type: K } & PromptOptionsType<K>
-  }
-  >
+      {
+        [K in PromptTypes]-?: T extends true ? { type: K } & PromptOptionsType<K> & { name: string | (() => string) } : { type: K } & PromptOptionsType<K>
+      }
+    >
   | ({
-    type: string
-  } & T extends true
-    ? PromptOptionsType<string> & { name: string | (() => string) }
-    : PromptOptionsType<string>)
+      type: string
+    } & T extends true
+      ? PromptOptionsType<string> & { name: string | (() => string) }
+      : PromptOptionsType<string>)
 
 export type Unionize<T extends Record<string, unknown>> = {
   [P in keyof T]: T[P]
@@ -129,48 +128,53 @@ export type PromptTypes =
 export type PromptOptionsType<T> = T extends 'AutoComplete'
   ? ArrayPromptOptions
   : T extends 'BasicAuth'
-    ? StringPromptOptions
-    : T extends 'Confirm'
-      ? BooleanPromptOptions
-      : T extends 'Editable'
-        ? ArrayPromptOptions
-        : T extends 'Form'
-          ? ArrayPromptOptions
-          : T extends 'Input'
-            ? StringPromptOptions
-            : T extends 'Invisible'
-              ? StringPromptOptions
-              : T extends 'List'
-                ? ArrayPromptOptions
-                : T extends 'MultiSelect'
-                  ? ArrayPromptOptions
-                  : T extends 'Numeral'
-                    ? NumberPromptOptions
-                    : T extends 'Password'
-                      ? StringPromptOptions
-                      : T extends 'Quiz'
-                        ? QuizPromptOptions
-                        : T extends 'Scale'
-                          ? ScalePromptOptions
-                          : T extends 'Select'
-                            ? ArrayPromptOptions
-                            : T extends 'Snippet'
-                              ? SnippetPromptOptions
-                              : T extends 'Sort'
-                                ? SortPromptOptions
-                                : T extends 'Survey'
-                                  ? SurveyPromptOptions
-                                  : T extends 'Text'
-                                    ? StringPromptOptions
-                                    : T extends 'Toggle'
-                                      ? TogglePromptOptions
-                                      : T extends string
-                                        ? BasePromptOptions & Record<string, unknown>
-                                        : any
+  ? StringPromptOptions
+  : T extends 'Confirm'
+  ? BooleanPromptOptions
+  : T extends 'Editable'
+  ? ArrayPromptOptions
+  : T extends 'Form'
+  ? ArrayPromptOptions
+  : T extends 'Input'
+  ? StringPromptOptions
+  : T extends 'Invisible'
+  ? StringPromptOptions
+  : T extends 'List'
+  ? ArrayPromptOptions
+  : T extends 'MultiSelect'
+  ? ArrayPromptOptions
+  : T extends 'Numeral'
+  ? NumberPromptOptions
+  : T extends 'Password'
+  ? StringPromptOptions
+  : T extends 'Quiz'
+  ? QuizPromptOptions
+  : T extends 'Scale'
+  ? ScalePromptOptions
+  : T extends 'Select'
+  ? ArrayPromptOptions
+  : T extends 'Snippet'
+  ? SnippetPromptOptions
+  : T extends 'Sort'
+  ? SortPromptOptions
+  : T extends 'Survey'
+  ? SurveyPromptOptions
+  : T extends 'Text'
+  ? StringPromptOptions
+  : T extends 'Toggle'
+  ? TogglePromptOptions
+  : T extends string
+  ? BasePromptOptions & Record<string, unknown>
+  : any
 
 export interface PromptSettings {
   error?: boolean
   cancelCallback?: (settings?: PromptSettings) => string | Error | PromptError | void
   stdout?: WriteStream | Writable
   enquirer?: Enquirer
+}
+
+export interface PromptInstance extends Omit<BasePromptOptions, 'onCancel' | 'onSubmit'> {
+  submit(): void
+  cancel(err?: string): void
 }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -43,11 +43,11 @@ export async function createPrompt(this: TaskWrapper<any, any>, options: PromptO
   }
 
   // Capture the prompt instance so we can use it later
-  enquirer.once('prompt', (prompt: PromptInstance) => (this.task.prompt = prompt))
+  enquirer.on('prompt', (prompt: PromptInstance) => (this.task.prompt = prompt))
 
   // Clear the prompt instance once it's submitted
   // Can't use on cancel, since that might hold a PromptError object
-  enquirer.once('submit', () => (this.task.prompt = undefined))
+  enquirer.on('submit', () => (this.task.prompt = undefined))
 
   this.task.subscribe((event) => {
     if (event.type === 'STATE' && event.data === stateConstants.SKIPPED) {

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -68,6 +68,7 @@ export async function createPrompt(this: TaskWrapper<any, any>, options: PromptO
 }
 
 export function destroyPrompt(this: TaskWrapper<any, any>, throwError = false) {
+  if (!this.promptInstance) return // If there's no prompt, can't cancel
   if (throwError) this.promptInstance.cancel()
   this.promptInstance.submit()
 }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,12 +1,10 @@
-import Enquirer from 'enquirer'
-
-import { StateConstants } from './../interfaces/listr.interface'
-import { PromptOptions, PromptSettings } from './prompt.interface'
 import { PromptError } from '@interfaces/listr.interface'
 import { stateConstants } from '@root/interfaces/state.constants'
 import { TaskWrapper } from '@root/lib/task-wrapper'
+import Enquirer from 'enquirer'
+import { PromptInstance, PromptOptions, PromptSettings } from './prompt.interface'
 
-export async function createPrompt (this: TaskWrapper<any, any>, options: PromptOptions | PromptOptions<true>[], settings?: PromptSettings): Promise<any> {
+export async function createPrompt(this: TaskWrapper<any, any>, options: PromptOptions | PromptOptions<true>[], settings?: PromptSettings): Promise<any> {
   // override cancel callback
   let cancelCallback: PromptSettings['cancelCallback']
   /* istanbul ignore if */
@@ -19,19 +17,19 @@ export async function createPrompt (this: TaskWrapper<any, any>, options: Prompt
   // assign default if there is single prompt
   /* istanbul ignore else if */
   if (!Array.isArray(options)) {
-    options = [ { ...options, name: 'default' } ]
+    options = [{ ...options, name: 'default' }]
   } else if (options.length === 1) {
     options = options.reduce((o, option) => {
-      return [ ...o, Object.assign(option, { name: 'default' }) ]
+      return [...o, Object.assign(option, { name: 'default' })]
     }, [])
   }
 
   // assign default enquirer options}
   options = options.reduce((o, option) => {
-    return [ ...o, Object.assign(option, { stdout: settings?.stdout ?? this.stdout(), onCancel: cancelCallback.bind(this, settings) }) ]
+    return [...o, Object.assign(option, { stdout: settings?.stdout ?? this.stdout(), onCancel: cancelCallback.bind(this, settings) })]
   }, [])
 
-  let enquirer: Enquirer
+  let enquirer: Enquirer<object>
   if (settings?.enquirer) {
     // injected enquirer
     enquirer = settings.enquirer
@@ -44,19 +42,24 @@ export async function createPrompt (this: TaskWrapper<any, any>, options: Prompt
     }
   }
 
-  // return default name if it is single prompt
-  enquirer.once('prompt', (prompt) => {
-    this.task.subscribe((event) => {
-      if (event.type === 'STATE' && event.data === stateConstants.SKIPPED) {
-        this.task.prompt = false
-        prompt.submit()
-      }
-    })
+  // Capture the prompt instance so we can use it later
+  enquirer.once('prompt', (prompt: PromptInstance) => (this.promptInstance = prompt))
+
+  // Clear the prompt instance
+  enquirer.once('cancel', () => (this.promptInstance = undefined))
+  enquirer.once('submit', () => (this.promptInstance = undefined))
+
+  this.task.subscribe((event) => {
+    if (event.type === 'STATE' && event.data === stateConstants.SKIPPED) {
+      this.task.prompt = false
+      this.promptInstance.submit()
+    }
   })
 
   this.task.prompt = true
   const response = (await enquirer.prompt(options as any)) as any
 
+  // return default name if it is single prompt
   if (options.length === 1) {
     return response.default
   } else {
@@ -64,7 +67,12 @@ export async function createPrompt (this: TaskWrapper<any, any>, options: Prompt
   }
 }
 
-function defaultCancelCallback (settings: PromptSettings): string | Error | PromptError | void {
+export function destroyPrompt(this: TaskWrapper<any, any>, throwError = false) {
+  if (throwError) this.promptInstance.cancel()
+  this.promptInstance.submit()
+}
+
+function defaultCancelCallback(settings: PromptSettings): string | Error | PromptError | void {
   const errorMsg = 'Cancelled prompt.'
 
   if (settings?.error === true) {


### PR DESCRIPTION
This adds functionality for `cancelPrompt` that can exposed to the task itself

## Caveat
There's currently a bug with using multiple prompts when reusing `task.prompt`

@cenk1cenk2 can you take a look at this?

Closes #177 