### PR TITLE
Enable tsconfig `strict` and `noImplicitAny` flags

### DIFF
--- a/src/renderer/default.renderer.ts
+++ b/src/renderer/default.renderer.ts
@@ -419,7 +419,7 @@ export class DefaultRenderer implements ListrRenderer {
         this.bottomBar[key].data = this.bottomBar[key].data.slice(-this.bottomBar[key].items)
         o[key].data = this.bottomBar[key].data
         return o
-      }, {})
+      }, {} as Record<string, { data?: string[], items?: number} | undefined>)
 
       return Object.values(this.bottomBar)
         .reduce((o, value) => o = [ ...o, ...value.data ], [])

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -101,7 +101,7 @@ export function destroyPrompt (this: TaskWrapper<any, any>, throwError = false):
   }
 }
 
-function defaultCancelCallback (settings: PromptSettings): string | Error | PromptError | void {
+function defaultCancelCallback (this: any, settings: PromptSettings): string | Error | PromptError | void {
   const errorMsg = 'Cancelled prompt.'
 
   if (this instanceof TaskWrapper) {

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -14,7 +14,7 @@ import { TaskWrapper } from '@lib/task-wrapper'
  * @param options
  * @param settings
  */
-export async function createPrompt (options: PromptOptions | PromptOptions<true>[], settings?: PromptSettings): Promise<any> {
+export async function createPrompt (this: any, options: PromptOptions | PromptOptions<true>[], settings?: PromptSettings): Promise<any> {
   // override cancel callback
   let cancelCallback: PromptSettings['cancelCallback']
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "allowSyntheticDefaultImports": false,
     "incremental": true,
     "noImplicitAny": true,
+    "strict": true,
     "strictNullChecks": false,
     "esModuleInterop": false,
     "outDir": "./dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": false,
     "incremental": true,
+    "noImplicitAny": true,
     "strictNullChecks": false,
     "esModuleInterop": false,
     "outDir": "./dist",


### PR DESCRIPTION
This PR begins to _tighten up_ some of the ts compiler settings. It is purely a change to type information, and should not have any impact on the build output.