### PR TITLE
feat: use elegant spinner on environments that support unicode

### DIFF
--- a/src/renderer/default.renderer.ts
+++ b/src/renderer/default.renderer.ts
@@ -9,6 +9,7 @@ import { ListrContext } from '@interfaces/listr.interface'
 import { ListrRenderer } from '@interfaces/renderer.interface'
 import { Task } from '@lib/task'
 import chalk from '@utils/chalk'
+import { isUnicodeSupported } from '@utils/is-unicode-supported'
 import { parseTaskTime } from '@utils/parse-time'
 
 /** Default updating renderer for Listr2 */
@@ -150,7 +151,7 @@ export class DefaultRenderer implements ListrRenderer {
   private id?: NodeJS.Timeout
   private bottomBar: { [uuid: string]: { data?: string[], items?: number } } = {}
   private promptBar: string
-  private spinner: string[] = process.platform === 'win32' && !process.env.WT_SESSION ? [ '-', '\\', '|', '/' ] : [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ]
+  private spinner: string[] = !isUnicodeSupported() ? [ '-', '\\', '|', '/' ] : [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ]
   private spinnerPosition = 0
 
   constructor (public tasks: Task<any, typeof DefaultRenderer>[], public options: typeof DefaultRenderer['rendererOptions'], public renderHook$?: Task<any, any>['renderHook$']) {

--- a/src/utils/is-unicode-supported.ts
+++ b/src/utils/is-unicode-supported.ts
@@ -1,0 +1,11 @@
+export function isUnicodeSupported (): boolean {
+  if (process.platform !== 'win32') {
+    return true
+  }
+
+  return Boolean(process.env.CI) ||
+		Boolean(process.env.WT_SESSION) ||
+		process.env.TERM_PROGRAM === 'vscode' ||
+		process.env.TERM === 'xterm-256color' ||
+		process.env.TERM === 'alacritty'
+}


### PR DESCRIPTION
Currently, Listr only uses the elegant spinners on Windows on the Windows Terminal.

This commits adds another environments that are known to have support for unicode characters and thus, the elegant spinners. 

The initial idea was to simply use [is-unicode-supported](https://github.com/sindresorhus/is-unicode-supported). However, that package doesn't really fits this package's build because v1.0.0 is shipped only as ESM and v0.1.0 would require allowSyntheticDefaultImports or esModuleInterop, which has been removed in this package's config.

Given this situation, I pretty much added a function exactly like sindresorhus' until there's a solution to use the proper package. I will look into open a PR for adding support for no module interop in is-unicode-supported, but I think it's worth adding the elegant spinners at least for VSCode for now.