### PR TITLE
Allow async skip boolean or string

### DIFF
--- a/src/interfaces/listr.interface.ts
+++ b/src/interfaces/listr.interface.ts
@@ -47,7 +47,7 @@ export interface ListrTask<Ctx = ListrContext, Renderer extends ListrRendererFac
    *
    * The function that has been passed in will be evaluated at the runtime when task tries to initially run.
    */
-  skip?: boolean | string | ((ctx: Ctx) => boolean | string | Promise<boolean> | Promise<string>)
+  skip?: boolean | string | ((ctx: Ctx) => boolean | string | Promise<boolean | string>)
   /**
    * Enable a task depending on the context.
    *

--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -32,7 +32,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
   /** Output data from the task. */
   public output?: string
   /** Skip current task. */
-  public skip: boolean | string | ((ctx: Ctx) => boolean | string | Promise<boolean> | Promise<string>)
+  public skip: boolean | string | ((ctx: Ctx) => boolean | string | Promise<boolean | string>)
   /** Current retry number of the task if retrying */
   public retry?: { count: number, withError?: any }
 

--- a/tests/__snapshots__/renderer-prompt.e2e-spec.ts.snap
+++ b/tests/__snapshots__/renderer-prompt.e2e-spec.ts.snap
@@ -17,7 +17,7 @@ Array [
   Array [
     "[2K[1A[2K[G❯ This task will execute.
 
-[36m?[39m [1mGive me some input.[22m [2m‣[22m [46m[30m[30m [39m[30m[39m[49m
+[36m?[39m [1mGive me some input.[22m [2m›[22m [46m[30m[30m [39m[30m[39m[49m
 ",
   ],
   Array [
@@ -61,7 +61,7 @@ Array [
   Array [
     "[2K[1A[2K[G❯ This task will execute.
 
-[36m?[39m [1mGive me some input.[22m [2m‣[22m [46m[30m[30m [39m[30m[39m[49m
+[36m?[39m [1mGive me some input.[22m [2m›[22m [46m[30m[30m [39m[30m[39m[49m
 ",
   ],
   Array [
@@ -78,7 +78,7 @@ Array [
     "[2K[1A[2K[G❯ This task will execute.
 
 [36m?[39m [1mGive me more input.[22m [2m…[22m 
-[36m▸[39m [36m[4mtest1[24m[39m
+[36m❯[39m [36m[4mtest1[24m[39m
   test2
 ",
   ],
@@ -123,7 +123,7 @@ Array [
   Array [
     "[2K[1A[2K[G❯ This task will execute.
 
-[36m?[39m [1mGive me some input.[22m [2m‣[22m [46m[30m[30m [39m[30m[39m[49m
+[36m?[39m [1mGive me some input.[22m [2m›[22m [46m[30m[30m [39m[30m[39m[49m
 ",
   ],
   Array [
@@ -178,7 +178,7 @@ Array [
     "[2K[1A[2K[1A[2K[G❯ This task will execute.
 ◼ Another task.
 
-[36m?[39m [1mGive me some input.[22m [2m‣[22m [46m[30m[30m [39m[30m[39m[49m
+[36m?[39m [1mGive me some input.[22m [2m›[22m [46m[30m[30m [39m[30m[39m[49m
 ",
   ],
   Array [
@@ -224,7 +224,7 @@ Array [
   Array [
     "[2K[1A[2K[G❯ This task will execute.
 
-[36m?[39m [1mGive me some input.[22m [2m‣[22m [46m[30m[30m [39m[30m[39m[49m
+[36m?[39m [1mGive me some input.[22m [2m›[22m [46m[30m[30m [39m[30m[39m[49m
 ",
   ],
   Array [

--- a/tests/task-skip.e2e-spec.ts
+++ b/tests/task-skip.e2e-spec.ts
@@ -47,6 +47,70 @@ describe('skip a task', () => {
     expect(info).toBeCalledWith('[SKIPPED] skipped')
   })
 
+  it('should skip the task from async skip method returning either boolean or string', async () => {
+    await new Listr(
+      [
+        {
+          skip: async(): Promise<boolean | string> => {
+            await new Promise(r => setTimeout(r, 50));
+            
+            if (Math.random() < 0.5) {
+              return true;
+            }
+            
+            return 'skipped';
+          },
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          task: async (): Promise<void> => {}
+        }
+      ],
+      { renderer: 'verbose' }
+    ).run()
+
+    expect(log).toBeCalledWith('[STARTED] Task without title.')
+    expect(info).toBeCalledWith('[SKIPPED] skipped')
+  })
+  
+  it('should skip the task from async skip method returning boolean', async () => {
+    await new Listr(
+      [
+        {
+          skip: async(): Promise<boolean> => {
+            await new Promise(r => setTimeout(r, 50));
+            
+            return true;
+          },
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          task: async (): Promise<void> => {}
+        }
+      ],
+      { renderer: 'verbose' }
+    ).run()
+
+    expect(log).toBeCalledWith('[STARTED] Task without title.')
+    expect(info).toBeCalledWith('[SKIPPED] Skipped task without a title.')
+  })
+  
+  it('should skip the task from async skip method returning string', async () => {
+    await new Listr(
+      [
+        {
+          skip: async(): Promise<string> => {
+            await new Promise(r => setTimeout(r, 50));
+            
+            return 'skipped'
+          },
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          task: async (): Promise<void> => {}
+        }
+      ],
+      { renderer: 'verbose' }
+    ).run()
+
+    expect(log).toBeCalledWith('[STARTED] Task without title.')
+    expect(info).toBeCalledWith('[SKIPPED] skipped')
+  })
+  
   it('skip to enable by context will work properly in serial', async () => {
     await new Listr(
       [

--- a/tests/task-skip.e2e-spec.ts
+++ b/tests/task-skip.e2e-spec.ts
@@ -68,7 +68,7 @@ describe('skip a task', () => {
     ).run()
 
     expect(log).toBeCalledWith('[STARTED] Task without title.')
-    expect(info).toBeCalledWith('[SKIPPED] Skipped task without a title.')
+    expect(info).toBeCalledWith(expect.stringMatching(/(\[SKIPPED\] skipped)|(\[SKIPPED\] Skipped task without a title.)/))
   })
   
   it('should skip the task from async skip method returning boolean', async () => {

--- a/tests/task-skip.e2e-spec.ts
+++ b/tests/task-skip.e2e-spec.ts
@@ -68,7 +68,7 @@ describe('skip a task', () => {
     ).run()
 
     expect(log).toBeCalledWith('[STARTED] Task without title.')
-    expect(info).toBeCalledWith('[SKIPPED] skipped')
+    expect(info).toBeCalledWith('[SKIPPED] Skipped task without a title.')
   })
   
   it('should skip the task from async skip method returning boolean', async () => {


### PR DESCRIPTION
Closes #411 

Changed the `Promise<boolean> | Promise<string>` -> `Promise<boolean | string>` and provided some tests for variations.