### PR TITLE
Fix/faster cloning

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
   ],
   "dependencies": {
     "cli-truncate": "^2.1.0",
-    "clone": "^2.1.2",
     "colorette": "^2.0.16",
     "log-update": "^4.0.0",
     "p-map": "^4.0.0",
+    "rfdc": "^1.3.0",
     "rxjs": "^7.4.0",
     "through": "^2.3.8",
     "wrap-ansi": "^7.0.0"

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,4 +1,6 @@
-import * as clone from 'clone'
+import * as rfdc from 'rfdc'
+
+const clone = rfdc({ circles: true })
 
 /**
  * Deep clones a object in the most easiest manner.

--- a/tests/general.e2e-spec.ts
+++ b/tests/general.e2e-spec.ts
@@ -69,4 +69,39 @@ describe('show output from task', () => {
     expect(ctx.test).toBe(true)
     expect(ctx.test2).toBe(true)
   })
+
+  // Jest timeout does not work here as cloneObject(ctx) is eating up all cpu
+  // cycles, i.e. the stack frame take a long time to complete.
+  it('should not take an unreasonable amount of time to clone a large ctx object during error collection', async () => {
+    const ctx = createLargeNestedObject(6, 8) // About 20Mb
+    const start = Date.now()
+    try {
+      await new Listr(
+        [
+          {
+            title: 'This task will fail.',
+            task: (): void => {
+              throw new Error('This task failed.')
+            }
+          }
+        ],
+        {
+          exitOnError: true
+        }
+      ).run(ctx)
+    } catch (e: any) {
+      // Ignore
+    }
+    const end = Date.now()
+
+    expect(end - start).toBeLessThan(10000)
+  })
 })
+
+function createLargeNestedObject (depth: number, branches: number): Record<PropertyKey, any> {
+  const obj: Record<PropertyKey, any> = {}
+  for (let i = 0; i < branches; ++i) {
+    obj['k' + i] = depth === 0 ? 'v' : createLargeNestedObject(depth - 1, branches)
+  }
+  return obj
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4797,6 +4797,11 @@ rewire@^5.0.0:
   dependencies:
     eslint "^6.8.0"
 
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"


### PR DESCRIPTION
Improve unreasonably slow context cloning during error collection with large context objects. Basically replaced the clone package with the rfdc package.