### PR TITLE
fix(enquirer): Add hint attr for array prompts

### DIFF
--- a/src/utils/prompt.interface.ts
+++ b/src/utils/prompt.interface.ts
@@ -37,6 +37,7 @@ interface ArrayPromptOptions extends BasePromptOptions {
   edgeLength?: number
   align?: 'left' | 'right'
   scroll?: boolean
+  hint?: string
 }
 
 interface BooleanPromptOptions extends BasePromptOptions {


### PR DESCRIPTION
See https://github.com/enquirer/enquirer#arrayprompt
This option is available for all array prompts.
Some examples: https://github.com/enquirer/enquirer/blob/master/examples/multiselect/option-hint.js, https://github.com/enquirer/enquirer/blob/master/examples/sort/prompt.js