### PR TITLE
fix: Use 'isObservable' utility instance of 'instanceof'

### DIFF
--- a/src/lib/task.ts
+++ b/src/lib/task.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject } from 'rxjs'
+import { isObservable, Subject } from 'rxjs'
 import { Readable } from 'stream'
 
 import type { TaskWrapper } from './task-wrapper'
@@ -237,7 +237,7 @@ export class Task<Ctx, Renderer extends ListrRendererFactory> extends Subject<Li
           result.on('error', (error: Error) => reject(error))
           result.on('end', () => resolve(null))
         })
-      } else if (result instanceof Observable) {
+      } else if (isObservable(result)) {
         // Detect Observable
         result = new Promise((resolve, reject) => {
           result.subscribe({


### PR DESCRIPTION
Using `instanceof Observable` can fail in cases where the observables come from two different copies of `rxjs` that might be installed in your node_modules. When this condition fails, it causes the task to immediately complete as if it were successful.